### PR TITLE
Update Chrome Web Store Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # UT Registration Plus
-[Try it for yourself on the Chrome Web Store](https://chrome.google.com/webstore/detail/hboadpjkoaieogjimneceaahlppnipaa/publish-accepted?authuser=0&hl=en-US)
+[Try it for yourself on the Chrome Web Store](https://chrome.google.com/webstore/detail/hboadpjkoaieogjimneceaahlppnipaa)
 
 We've all been there. 20 tabs of Rate My Professor, Catalyst, and the UT Course Catalog open and you still don't know what classes to take. 
 This extension tries to streamline most of the unnecessary steps and headaches of registering for classes at UT Austin. 


### PR DESCRIPTION
The original URL cannot be used to add the Extension to the browser. See the screenshots for the differences (account is masked):
![image](https://user-images.githubusercontent.com/35571479/55865325-b3c64d00-5bb0-11e9-9bd5-5bf89b15843b.png)
![image](https://user-images.githubusercontent.com/35571479/55865400-da848380-5bb0-11e9-843c-8061b8e78a58.png)
