### PR TITLE
Names are now displayed correctly in options page

### DIFF
--- a/js/options.js
+++ b/js/options.js
@@ -35,8 +35,13 @@ $.get("https://api.github.com/repos/sghsri/UT-Registration-Plus/stats/contributo
     for (var contributorData of data) {
         $.get(`https://api.github.com/users/${contributorData.author.login}`, userData => {
             let fullData = { ...contributorData, ...userData };
-            let { login, avatar_url, html_url } = fullData;
-            $("#contributor-list").append(Template.Options.contributor_card(login, "name", avatar_url, html_url));
+            let { login, avatar_url, html_url, name } = fullData;
+            if(name){
+                $("#contributor-list").append(Template.Options.contributor_card(login, name, avatar_url, html_url));
+            }
+            else{
+                $("#contributor-list").append(Template.Options.contributor_card("", login, avatar_url, html_url));
+            }
         });
     }
 });


### PR DESCRIPTION
If the contributor has their name on their github profile, it is displayed and bolded with the username underneath. If they don't have their name on their profile, their username is put in place of it and bolded.