### PR TITLE
Fixes cutoff PNGs. Exporting as PNG accounts for device DPI. 

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -255,8 +255,8 @@ function buildICSFile(cal, event) {
 }
 
 function takePicture() {
-    var width = $("#calendar").width();
-    var height = $("#calendar").height();
+    var width = $("#calendar").width() * window.devicePixelRatio;
+    var height = $("#calendar").height() * window.devicePixelRatio;
     let cropper = document.createElement('canvas').getContext('2d');
     html2canvas(document.querySelector("#calendar"), Export.png_options).then(c => {
         cropper.canvas.width = width;


### PR DESCRIPTION
The takePicture function would cut off the image. This is because some devices have high DPI resulting in a zoom making the width and height for the screenshot inaccurate. 

Cutoff Screenshot
![mySchedule (4)](https://user-images.githubusercontent.com/53070748/185973455-0e177558-2096-43a9-90c1-fc0c2ae9b53d.png)

Screenshot after accounting for device DPI
![mySchedule (6)](https://user-images.githubusercontent.com/53070748/185973743-243facba-5ed7-4e50-a39a-c09460369dee.png)

