### PR TITLE
feat: start calendar course block component

### DIFF
--- a/src/stories/components/CalendarCourseBlock.stories.tsx
+++ b/src/stories/components/CalendarCourseBlock.stories.tsx
@@ -1,0 +1,62 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { Course, Status } from 'src/shared/types/Course';
+import { CourseMeeting, DAY_MAP } from 'src/shared/types/CourseMeeting';
+import { CourseSchedule } from 'src/shared/types/CourseSchedule';
+import Instructor from 'src/shared/types/Instructor';
+import CalendarCourse from 'src/views/components/common/CalendarCourseBlock/CalendarCourseBlock';
+
+const meta = {
+    title: 'Components/Common/CalendarCourseMeeting',
+    component: CalendarCourse,
+    parameters: {
+        layout: 'centered',
+    },
+    tags: ['autodocs'],
+    argTypes: {
+        course: { control: 'object' },
+        meetingIdx: { control: 'number' },
+        color: { control: 'color' },
+        rightIcon: { control: 'object' },
+    },
+} satisfies Meta<typeof CalendarCourse>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        course: new Course({
+            uniqueId: 123,
+            number: '311C',
+            fullName: "311C - Bevo's Default Course",
+            courseName: "Bevo's Default Course",
+            department: 'BVO',
+            creditHours: 3,
+            status: Status.WAITLISTED,
+            instructors: [new Instructor({ firstName: '', lastName: 'Bevo', fullName: 'Bevo' })],
+            isReserved: false,
+            url: '',
+            flags: [],
+            schedule: new CourseSchedule({
+                meetings: [
+                    new CourseMeeting({
+                        days: [DAY_MAP.M, DAY_MAP.W, DAY_MAP.F],
+                        startTime: 480,
+                        endTime: 570,
+                        location: {
+                            building: 'UTC',
+                            room: '123',
+                        },
+                    }),
+                ],
+            }),
+            instructionMode: 'In Person',
+            semester: {
+                year: 2024,
+                season: 'Spring',
+            },
+        }),
+        meetingIdx: 0,
+        color: 'red',
+    },
+};

--- a/src/stories/components/CalendarCourseBlock.stories.tsx
+++ b/src/stories/components/CalendarCourseBlock.stories.tsx
@@ -3,11 +3,11 @@ import { Course, Status } from 'src/shared/types/Course';
 import { CourseMeeting, DAY_MAP } from 'src/shared/types/CourseMeeting';
 import { CourseSchedule } from 'src/shared/types/CourseSchedule';
 import Instructor from 'src/shared/types/Instructor';
-import CalendarCourse from 'src/views/components/common/CalendarCourseBlock/CalendarCourseBlock';
+import CalendarCourseBlock from 'src/views/components/common/CalendarCourseBlock/CalendarCourseBlock';
 
 const meta = {
-    title: 'Components/Common/CalendarCourseMeeting',
-    component: CalendarCourse,
+    title: 'Components/Common/CalendarCourseBlock',
+    component: CalendarCourseBlock,
     parameters: {
         layout: 'centered',
     },
@@ -16,9 +16,8 @@ const meta = {
         course: { control: 'object' },
         meetingIdx: { control: 'number' },
         color: { control: 'color' },
-        rightIcon: { control: 'object' },
     },
-} satisfies Meta<typeof CalendarCourse>;
+} satisfies Meta<typeof CalendarCourseBlock>;
 export default meta;
 
 type Story = StoryObj<typeof meta>;

--- a/src/views/components/common/CalendarCourseBlock/CalendarCourseBlock.module.scss
+++ b/src/views/components/common/CalendarCourseBlock/CalendarCourseBlock.module.scss
@@ -20,6 +20,7 @@
             align-items: flex-start;
             gap: 5px;
             flex: 1 0 0;
+            line-height: 100%;
         }
         .course-status {
             display: flex;
@@ -31,6 +32,7 @@
             height: 23px;
             width: 23px;
             border-radius: 4px;
+            line-height: 100%;
         }
     }
 }

--- a/src/views/components/common/CalendarCourseBlock/CalendarCourseBlock.module.scss
+++ b/src/views/components/common/CalendarCourseBlock/CalendarCourseBlock.module.scss
@@ -1,21 +1,36 @@
 .component {
+    background: #cbd5e1;
+    border-radius: 4px;
     display: flex;
     padding: 7px 7px 9px 7px;
     flex-direction: column;
     align-items: flex-start;
-    gap: 5px;
-    flex: 1 0 0;
-    align-self: stretch;
-    border-radius: 4px;
-    background: #cbd5e1;
     .content {
+        width: 184px;
         display: flex;
-        gap: 7px;
+        align-items: flex-start;
+        align-content: flex-start;
+        gap: 5px 7px;
+        align-self: stretch;
+        flex-wrap: wrap;
         .course-detail {
             display: flex;
+            min-width: 26px;
             flex-direction: column;
+            align-items: flex-start;
             gap: 5px;
-            width: 154px;
+            flex: 1 0 0;
+        }
+        .course-status {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 7px;
+            background: #334155;
+            color: #ffffff;
+            height: 23px;
+            width: 23px;
+            border-radius: 4px;
         }
     }
 }

--- a/src/views/components/common/CalendarCourseBlock/CalendarCourseBlock.module.scss
+++ b/src/views/components/common/CalendarCourseBlock/CalendarCourseBlock.module.scss
@@ -1,0 +1,21 @@
+.component {
+    display: flex;
+    padding: 7px 7px 9px 7px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 5px;
+    flex: 1 0 0;
+    align-self: stretch;
+    border-radius: 4px;
+    background: #cbd5e1;
+    .content {
+        display: flex;
+        gap: 7px;
+        .course-detail {
+            display: flex;
+            flex-direction: column;
+            gap: 5px;
+            width: 154px;
+        }
+    }
+}

--- a/src/views/components/common/CalendarCourseBlock/CalendarCourseBlock.tsx
+++ b/src/views/components/common/CalendarCourseBlock/CalendarCourseBlock.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Course } from 'src/shared/types/Course';
+import { CourseMeeting } from 'src/shared/types/CourseMeeting';
+import Text from '../Text/Text';
+import styles from './CalendarCourseBlock.module.scss';
+
+export interface CalendarCourseBlockProps {
+    /** The Course that the meeting is for. */
+    course: Course;
+    /* index into course meeting array to display */
+    meetingIdx?: number;
+    /** The background color for the course. */
+    color: string;
+}
+
+const CalendarCourseBlock: React.FC<CalendarCourseBlockProps> = ({ course, meetingIdx }: CalendarCourseBlockProps) => {
+    let meeting: CourseMeeting | null = meetingIdx !== undefined ? course.schedule.meetings[meetingIdx] : null;
+    return (
+        <div className={styles.component}>
+            <div className={styles.content}>
+                <div className={styles['course-detail']}>
+                    <Text variant='h1-course'>
+                        {course.department} {course.number} - {course.instructors[0].lastName}
+                    </Text>
+                    <Text variant='h3-course'>
+                        {`${meeting.getTimeString({ separator: '-', capitalize: true })}${
+                            meeting.location ? ` - ${meeting.location.building}` : ''
+                        }`}
+                    </Text>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default CalendarCourseBlock;

--- a/src/views/components/common/CalendarCourseBlock/CalendarCourseBlock.tsx
+++ b/src/views/components/common/CalendarCourseBlock/CalendarCourseBlock.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
-import { Course } from 'src/shared/types/Course';
+import { Course, Status } from 'src/shared/types/Course';
 import { CourseMeeting } from 'src/shared/types/CourseMeeting';
+import ClosedIcon from '~icons/material-symbols/lock';
+import WaitlistIcon from '~icons/material-symbols/timelapse';
+import CancelledIcon from '~icons/material-symbols/warning';
 import Text from '../Text/Text';
 import styles from './CalendarCourseBlock.module.scss';
 
@@ -15,11 +18,20 @@ export interface CalendarCourseBlockProps {
 
 const CalendarCourseBlock: React.FC<CalendarCourseBlockProps> = ({ course, meetingIdx }: CalendarCourseBlockProps) => {
     let meeting: CourseMeeting | null = meetingIdx !== undefined ? course.schedule.meetings[meetingIdx] : null;
+    let rightIcon: React.ReactNode | null = null;
+    if (course.status === Status.WAITLISTED) {
+        rightIcon = <WaitlistIcon />;
+    } else if (course.status === Status.CLOSED) {
+        rightIcon = <ClosedIcon />;
+    } else if (course.status === Status.CANCELLED) {
+        rightIcon = <CancelledIcon />;
+    }
+
     return (
         <div className={styles.component}>
             <div className={styles.content}>
                 <div className={styles['course-detail']}>
-                    <Text variant='h1-course'>
+                    <Text variant='h1-course' className={styles['course-title']}>
                         {course.department} {course.number} - {course.instructors[0].lastName}
                     </Text>
                     <Text variant='h3-course'>
@@ -28,6 +40,7 @@ const CalendarCourseBlock: React.FC<CalendarCourseBlockProps> = ({ course, meeti
                         }`}
                     </Text>
                 </div>
+                {rightIcon && <div className={styles['course-status']}>{rightIcon}</div>}
             </div>
         </div>
     );


### PR DESCRIPTION
This PR starts the work on the calendar course block component. 
| Figma | Storybook |
| ------ | ----- |
| <img width="200" alt="Screenshot 2024-02-01 at 8 58 16 PM" src="https://github.com/sghsri/UT-Registration-Plus/assets/48454518/b068fba2-8641-4c0b-943e-aa852ed23d4a"> | <img width="200" alt="Screenshot 2024-02-01 at 8 58 50 PM" src="https://github.com/sghsri/UT-Registration-Plus/assets/48454518/f08fa7b1-881c-479a-80f7-35bdc08b975d"> |

I'm still waiting on the Text component and Icon component as well as tailwind for the styling and passing in a tailwind color as a prop for the background. Unless there's another way I should do this.
